### PR TITLE
fix: notion block의 type이 unknown인 경우 발생하는 문제 해결

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -172,6 +172,8 @@ def get_target_blocks(page, target_block_type):
 
     while q:
         block = q.popleft()
+        if block is None:
+            continue
         if isinstance(block, target_block_type):
             target_blocks.append(block)
 


### PR DESCRIPTION
#8 
- block 탐색 중 None인 경우 continue하도록 변경